### PR TITLE
Allow input pointers in picking parameters for autocompletion of params

### DIFF
--- a/topaz/protocols/protocol_topaz_picking.py
+++ b/topaz/protocols/protocol_topaz_picking.py
@@ -88,6 +88,7 @@ class TopazProtPicking(ProtParticlePickingAuto, ProtTopazBase):
     form.addSection('Picking')
     form.addParam('radius', params.IntParam, default=8,
                   label='Particle radius (px)',
+                  allowsPointers=True,
                   help='Pixel radius around particle centers to consider.')
     form.addParam('boxSize', params.IntParam, default=-1, expertLevel=cons.LEVEL_ADVANCED, allowsPointers=True,
                   label='Box size (px)', help='Box size in pixels. By default(-1): radius*2*scale')

--- a/topaz/protocols/protocol_topaz_training.py
+++ b/topaz/protocols/protocol_topaz_training.py
@@ -109,6 +109,7 @@ class TopazProtTraining(ProtParticlePicking, ProtTopazBase):
     form.addSection('Train')
     form.addParam('radius', params.IntParam, default=3,
                   label='Particle radius (px)',
+                  allowsPointers=True,
                   help='Pixel radius around particle centers to '
                        'consider.')
     form.addParam('autoenc', params.FloatParam, default=0.,
@@ -125,6 +126,7 @@ class TopazProtTraining(ProtParticlePicking, ProtTopazBase):
                   help='Objective function to use for learning the '
                        'region classifier.')
     form.addParam('numPartPerImg', params.IntParam, default=300,
+                  allowsPointers=True,
                   expertLevel=cons.LEVEL_ADVANCED,
                   label='Number of particles per image',
                   help='Expected number of particles per micrograph.')


### PR DESCRIPTION
-Protocol topaz picking: box size related parameters allow input pointers (i.e. radius)
-Protocol topaz training: box size related parameters allow input pointers (i.e. radius and num of particles per mic)