### PR TITLE
Force mkl==2024.0 in env creation to avoid 2024.1 deprecated symbols

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.0.3:
+    - Fix MKL version for Topaz 0.2.5
 3.0.2:
     - add topaz 0.2.5 support
 3.0.1:

--- a/topaz/__init__.py
+++ b/topaz/__init__.py
@@ -100,7 +100,7 @@ class Plugin(pwem.Plugin):
 
         toolkitVersion = "10.2" if cudaVersion.major == 10 else "11.3"
         # Install downloaded code
-        installationCmd += 'conda install -y topaz=%s cudatoolkit=%s '\
+        installationCmd += 'conda install -y mkl==2024.0 topaz=%s cudatoolkit=%s '\
                            '-c tbepler -c pytorch &&' % (version, toolkitVersion)
 
         # Flag installation finished


### PR DESCRIPTION
MKL 2024.1 breaks compat with Topaz 0.2.5 and needs to be pinned down to 2024.0 in topaz env